### PR TITLE
RunStateのボタン内のコンテンツの左揃え、及びProjectItemの参照をGlobalObjectIDに変更

### DIFF
--- a/Assets/AssetBookmarks/Editor/AssetBookmarksWindow.cs
+++ b/Assets/AssetBookmarks/Editor/AssetBookmarksWindow.cs
@@ -44,7 +44,6 @@ namespace AssetBookmarks.Editor
                 _state = nextState;
             }
         }
-
         private class Model
         {
             public Model()
@@ -66,7 +65,11 @@ namespace AssetBookmarks.Editor
 
                     if (e.Length == 2 && Enum.TryParse<OpenType>(e[1], out var t))
                     {
-                        Items.Add(new ProjectItem(e[0], t));
+                        if (GlobalObjectId.TryParse(e[0], out var globalObjectId))
+                        {
+                            var path = AssetDatabase.GUIDToAssetPath(globalObjectId.assetGUID.ToString());
+                            Items.Add(new ProjectItem(path, t));
+                        }
                     }
 
                     if (e.Length == 2 && e[0] == "o")
@@ -100,11 +103,12 @@ namespace AssetBookmarks.Editor
             {
                 Path = path;
                 OpenType = openType;
+                GlobalObjectID = GlobalObjectId.GetGlobalObjectIdSlow(AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(path));
             }
 
             public void Serialize(StringBuilder stringBuilder)
             {
-                stringBuilder.Append(Path);
+                stringBuilder.Append(GlobalObjectID.ToString());
                 stringBuilder.Append("|");
                 stringBuilder.Append(OpenType);
                 stringBuilder.Append(",");
@@ -112,6 +116,7 @@ namespace AssetBookmarks.Editor
 
             public string Path { get; }
             public OpenType OpenType { get; set; }
+            public GlobalObjectId GlobalObjectID { get; }
         }
 
         private class OutsideItem : IItem

--- a/Assets/AssetBookmarks/Editor/RunState.cs
+++ b/Assets/AssetBookmarks/Editor/RunState.cs
@@ -27,21 +27,24 @@ namespace AssetBookmarks.Editor
 
                 if (item is ProjectItem projectItem)
                 {
-                    var path = projectItem.Path;
+                    var globalObjectId = projectItem.GlobalObjectID;
+                    var path = AssetDatabase.GUIDToAssetPath(globalObjectId.assetGUID.ToString());
                     var name = Path.GetFileNameWithoutExtension(path);
                     var content = new GUIContent($" {projectItem.OpenType} {name}", AssetDatabase.GetCachedIcon(path));
-                    if (GUI.Button(rect, content))
+                    var style = new GUIStyle(GUI.skin.button) { alignment = TextAnchor.MiddleLeft };
+                    if (GUI.Button(rect, content, style))
                     {
+                        var asset = AssetDatabase.LoadAssetAtPath<Object>(path);
                         switch (projectItem.OpenType)
                         {
                             case OpenType.Open:
-                                AssetDatabase.OpenAsset(AssetDatabase.LoadAssetAtPath<Object>(path));
+                                AssetDatabase.OpenAsset(asset);
                                 break;
 
                             case OpenType.Focus:
                                 EditorUtility.FocusProjectWindow();
-                                EditorGUIUtility.PingObject(AssetDatabase.LoadAssetAtPath<Object>(path));
-                                Selection.activeObject = AssetDatabase.LoadAssetAtPath<Object>(path);
+                                EditorGUIUtility.PingObject(asset);
+                                Selection.activeObject = asset;
                                 EditorUtility.FocusProjectWindow();
                                 break;
 


### PR DESCRIPTION
* RunStateのボタンを左揃えに変更
* ProjectItemの参照をGlobalFileIDに変更

これらにより、アイコンやファイル名の位置が統一され視認性が向上するとともに、GlobalFileIDでの追跡によりリネームを含むパス変更に対応できるようになります。

初めてのフォーク及びプルリクエストのため、間違いや失礼があったら申し訳ございません。